### PR TITLE
Add Python-based framework for MSSQL to ORASS migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+
+# Virtual environments
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # migrator
+
+A simple configuration-driven Python framework to migrate data from
+Microsoft SQL Server to ORASS/Oracle databases without business
+transformation.
+
+## Usage
+
+1. Create a YAML configuration file:
+
+```yaml
+source:
+  connection_string: mssql+pyodbc://user:pass@dsn
+
+target:
+  connection_string: oracle+cx_oracle://user:pass@host:1521/?service_name=orass
+
+tables:
+  - source_table: employees
+    target_table: employees
+    batch_size: 1000
+```
+
+2. Run the migration:
+
+```bash
+python -m migrator.cli example_config.yml
+```
+
+## Development
+
+Install dependencies and run tests:
+
+```bash
+pip install -e .
+pytest
+```

--- a/example_config.yml
+++ b/example_config.yml
@@ -1,0 +1,10 @@
+source:
+  connection_string: mssql+pyodbc://user:pass@dsn
+
+target:
+  connection_string: oracle+cx_oracle://user:pass@host:1521/?service_name=orass
+
+tables:
+  - source_table: employees
+    target_table: employees
+    batch_size: 1000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "migrator"
+version = "0.1.0"
+description = "Data migration framework from MSSQL to ORASS"
+requires-python = ">=3.8"
+dependencies = [
+    "SQLAlchemy>=1.4",
+    "PyYAML>=6.0",
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/src/migrator/__init__.py
+++ b/src/migrator/__init__.py
@@ -1,0 +1,6 @@
+"""Migration framework package."""
+
+from .config import Config, TableMapping
+from .migrator import Migrator
+
+__all__ = ["Config", "TableMapping", "Migrator"]

--- a/src/migrator/cli.py
+++ b/src/migrator/cli.py
@@ -1,0 +1,23 @@
+"""Command line interface for migration framework."""
+
+from __future__ import annotations
+
+import argparse
+
+from .config import Config
+from .migrator import Migrator
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Migrate tables between databases")
+    parser.add_argument("config", help="Path to YAML configuration file")
+    args = parser.parse_args()
+
+    cfg = Config.from_file(args.config)
+    migrator = Migrator(cfg)
+    total = migrator.run()
+    print(f"Copied {total} rows")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    main()

--- a/src/migrator/config.py
+++ b/src/migrator/config.py
@@ -1,0 +1,38 @@
+"""Configuration utilities for migration framework."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+import yaml
+
+
+@dataclass
+class TableMapping:
+    """Mapping between source and target tables."""
+
+    source_table: str
+    target_table: str
+    batch_size: int = 1000
+
+
+@dataclass
+class Config:
+    """Configuration for a migration job."""
+
+    source_conn: str
+    target_conn: str
+    tables: List[TableMapping]
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "Config":
+        """Load configuration from a YAML file."""
+        with open(path, "r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+        tables = [TableMapping(**tbl) for tbl in data.get("tables", [])]
+        return cls(
+            source_conn=data["source"]["connection_string"],
+            target_conn=data["target"]["connection_string"],
+            tables=tables,
+        )

--- a/src/migrator/migrator.py
+++ b/src/migrator/migrator.py
@@ -1,0 +1,54 @@
+"""Core migration logic."""
+
+from __future__ import annotations
+
+from typing import Iterable
+from sqlalchemy import create_engine, Table, MetaData, select, insert
+
+from .config import Config, TableMapping
+
+
+class Migrator:
+    """Run table migrations between databases."""
+
+    def __init__(self, config: Config):
+        self.config = config
+
+    def migrate_table(self, mapping: TableMapping) -> int:
+        """Migrate a single table.
+
+        Returns the number of rows copied.
+        """
+        src_engine = create_engine(self.config.source_conn)
+        tgt_engine = create_engine(self.config.target_conn)
+
+        src_meta = MetaData(bind=src_engine)
+        tgt_meta = MetaData(bind=tgt_engine)
+        src_table = Table(mapping.source_table, src_meta, autoload_with=src_engine)
+        tgt_table = Table(mapping.target_table, tgt_meta, autoload_with=tgt_engine)
+
+        copied = 0
+        with src_engine.connect() as src_conn, tgt_engine.begin() as tgt_conn:
+            result = src_conn.execute(select(src_table))
+            rows: Iterable[dict] = (dict(row) for row in result.mappings())
+            batch: list[dict] = []
+            for row in rows:
+                batch.append(row)
+                if len(batch) >= mapping.batch_size:
+                    tgt_conn.execute(insert(tgt_table), batch)
+                    copied += len(batch)
+                    batch.clear()
+            if batch:
+                tgt_conn.execute(insert(tgt_table), batch)
+                copied += len(batch)
+        return copied
+
+    def run(self) -> int:
+        """Run migrations for all configured tables.
+
+        Returns the total number of rows copied.
+        """
+        total = 0
+        for mapping in self.config.tables:
+            total += self.migrate_table(mapping)
+        return total

--- a/tests/test_migrator.py
+++ b/tests/test_migrator.py
@@ -1,0 +1,31 @@
+from migrator.config import Config, TableMapping
+from migrator.migrator import Migrator
+from sqlalchemy import create_engine, text
+
+
+def setup_db(engine):
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)"))
+        conn.execute(text("INSERT INTO test (name) VALUES ('a'), ('b')"))
+
+
+def test_migrate_sqlite(tmp_path):
+    src = tmp_path / "src.db"
+    tgt = tmp_path / "tgt.db"
+    src_engine = create_engine(f"sqlite:///{src}")
+    tgt_engine = create_engine(f"sqlite:///{tgt}")
+    setup_db(src_engine)
+    with tgt_engine.begin() as conn:
+        conn.execute(text("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)"))
+
+    cfg = Config(
+        source_conn=f"sqlite:///{src}",
+        target_conn=f"sqlite:///{tgt}",
+        tables=[TableMapping(source_table="test", target_table="test", batch_size=1)],
+    )
+    migrator = Migrator(cfg)
+    copied = migrator.run()
+    assert copied == 2
+    with tgt_engine.connect() as conn:
+        result = conn.execute(text("SELECT COUNT(*) FROM test"))
+        assert result.scalar_one() == 2


### PR DESCRIPTION
## Summary
- add configurable framework for migrating tables between databases using SQLAlchemy
- provide CLI runner and sample configuration
- include basic test harness for SQLite-based verification

## Testing
- `python -m py_compile $(find src tests -name '*.py')`
- `PYTHONPATH=src pytest tests/test_migrator.py -q` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68a8218831fc8333bd3a81808e9e01a4